### PR TITLE
Add blog CTA to profile hero section and refresh testimonials

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
                 <div class="header-cta">
                     <a class="cta-button" href="#contact">Let's Connect</a>
                     <a class="cta-button ghost" href="books.html">Explore My Books</a>
+                    <a class="cta-button ghost" href="https://mentalmusings6.blogspot.com/" target="_blank" rel="noopener">Read My Blog</a>
                 </div>
             </div>
         </div>
@@ -417,32 +418,95 @@
             <div class="container">
                 <h2>Words from Learners &amp; Partners</h2>
                 <p class="section-intro">Feedback that keeps me grounded and inspired.</p>
-                <div class="testimonial-grid">
+                <div class="testimonial-grid flowing-panels">
                     <figure class="testimonial-card">
                         <blockquote>
-                            “Sudarshan effortlessly simplifies quant concepts that stump most aspirants. His empathy and rigour gave our cohort the clarity to ace CAT 2023.”
+                            <p>Sudarshan Sir is very eloquent and has a very elaborate teaching technique, making sure that all his ideas are articulated well to each of his students. He’s very knowledgeable and approachable, and shows keen interest in watching his students do better each day!</p>
                         </blockquote>
                         <figcaption>
-                            <span class="testimonial-name">Aditi Sharma</span>
-                            <span class="testimonial-meta">CAT 2023 Topper, Bengaluru</span>
+                            <span class="testimonial-name">Hrishit Sethia</span>
+                            <span class="testimonial-meta">CAT Learner</span>
                         </figcaption>
                     </figure>
                     <figure class="testimonial-card">
                         <blockquote>
-                            “Our sustainability think tank relied on his structured approach to life-cycle assessment. The insights shaped actionable policy recommendations.”
+                            <p>Sir’s dedication to teaching is truly inspiring. He explains concepts with clarity, patience, and depth, making even the most difficult topics easy to understand. His passion for the subject and commitment to students’ learning is unmatched.</p>
                         </blockquote>
                         <figcaption>
-                            <span class="testimonial-name">Dr. Meera Narayan</span>
-                            <span class="testimonial-meta">Program Lead, Climate Collective</span>
+                            <span class="testimonial-name">Surya Krishna</span>
+                            <span class="testimonial-meta">CAT Learner</span>
                         </figcaption>
                     </figure>
                     <figure class="testimonial-card">
                         <blockquote>
-                            “Workshops with Sudarshan are an experience—he blends Sanskrit wisdom with modern leadership frameworks that resonate deeply with young changemakers.”
+                            <p>I strongly recommend Sudharshan as an outstanding tutor. He is highly qualified in Sanskrit, Mathematics, and Science, and has a deep mastery of the Vedas. I know him personally through our Vedha classes, where his knowledge and dedication have truly stood out.</p>
                         </blockquote>
                         <figcaption>
-                            <span class="testimonial-name">Karthik Iyer</span>
-                            <span class="testimonial-meta">Founder, Prerana Learning Studio</span>
+                            <span class="testimonial-name">Veda Learner</span>
+                            <span class="testimonial-meta">Student</span>
+                        </figcaption>
+                    </figure>
+                    <figure class="testimonial-card">
+                        <blockquote>
+                            <p>Blessed to have such a Guru who can interpret the Sanatana truths in light of scientific facts. Through his classes he brings about a wonderful harmony of mythology, mysticism, and eternal truths in a simple and convincing manner which is relevant to modern minds. Sincerely grateful.</p>
+                        </blockquote>
+                        <figcaption>
+                            <span class="testimonial-name">Pushpa Jansari</span>
+                            <span class="testimonial-meta">Yoga teacher and practitioner</span>
+                        </figcaption>
+                    </figure>
+                    <figure class="testimonial-card">
+                        <blockquote>
+                            <p>A master of his craft who leads by example. Be it engg., medicine, business, environmental science or even Sanskrit, Sudarshan first aced all the exams as a topper himself (JEE, NEET, ICSE, KVPY - studied in IISc., GMAT, CAT) with single/double digit national ranks in many, before turning into a teacher.</p>
+                        </blockquote>
+                        <figcaption>
+                            <span class="testimonial-name">Rohit Kumar</span>
+                            <span class="testimonial-meta">XLRI MBA, Consultant</span>
+                        </figcaption>
+                    </figure>
+                    <figure class="testimonial-card">
+                        <blockquote>
+                            <p>Sudarshan is a graduate from IISc, Bengaluru. He is well-qualified to teach Sanskrit and modern science.</p>
+                        </blockquote>
+                        <figcaption>
+                            <span class="testimonial-name">Vid Shankararama Sharma</span>
+                            <span class="testimonial-meta">Scholar</span>
+                        </figcaption>
+                    </figure>
+                    <figure class="testimonial-card">
+                        <blockquote>
+                            <p>Sudarshan Sir is one of the samskrita scholars with great faith in the shastras and an excellent mathematician. Learning from him should be our goal and aim.</p>
+                        </blockquote>
+                        <figcaption>
+                            <span class="testimonial-name">Dr Tejas Bharadwaj</span>
+                            <span class="testimonial-meta">Ayurveda physician</span>
+                        </figcaption>
+                    </figure>
+                    <figure class="testimonial-card">
+                        <blockquote>
+                            <p>Sudarshan is one among the finest teachers I have seen. He puts all the efforts required to make a student learning the subject. His knowledge and hold on the subject is excellent.</p>
+                        </blockquote>
+                        <figcaption>
+                            <span class="testimonial-name">Purnananda V</span>
+                            <span class="testimonial-meta">Sanskrit propagator</span>
+                        </figcaption>
+                    </figure>
+                    <figure class="testimonial-card">
+                        <blockquote>
+                            <p>It was a wonderful experience learning from a young teacher who not only knew his theories well but was able to interact with students and make the transfer of knowledge practical!! The class plan was always such that not a minute was wasted and along with humour and games learning was joyful.</p>
+                        </blockquote>
+                        <figcaption>
+                            <span class="testimonial-name">Darshana Kamte</span>
+                            <span class="testimonial-meta">MA Sanskrit</span>
+                        </figcaption>
+                    </figure>
+                    <figure class="testimonial-card">
+                        <blockquote>
+                            <p>Sudarshan is a very good tutor. A good tutor is the one who has the ability to communicate in a way that makes the learner feel comfortable, motivated, and enjoy the learning. This skill is crucial for a successful tutor and I have seen this in Sudarshan. I would like to see improvement on conducting assessments from the initial stages when the student starts the classes. Overall had a good experience.</p>
+                        </blockquote>
+                        <figcaption>
+                            <span class="testimonial-name">Nivethitha S K</span>
+                            <span class="testimonial-meta">Parent</span>
                         </figcaption>
                     </figure>
                 </div>

--- a/style.css
+++ b/style.css
@@ -672,6 +672,39 @@ body.light-mode .text-link {
     gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
+.testimonial-grid.flowing-panels {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(280px, 1fr);
+    overflow-x: auto;
+    padding-bottom: 0.75rem;
+    scroll-snap-type: x mandatory;
+    gap: clamp(1.5rem, 4vw, 2.5rem);
+    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 163, 184, 0.4) transparent;
+}
+
+.testimonial-grid.flowing-panels::-webkit-scrollbar {
+    height: 6px;
+}
+
+.testimonial-grid.flowing-panels::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.testimonial-grid.flowing-panels::-webkit-scrollbar-thumb {
+    background-color: rgba(148, 163, 184, 0.4);
+    border-radius: 999px;
+}
+
+@media (min-width: 1024px) {
+    .testimonial-grid.flowing-panels {
+        grid-auto-flow: row;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        overflow-x: visible;
+        padding-bottom: 0;
+    }
+}
+
 .testimonial-card {
     display: flex;
     flex-direction: column;
@@ -686,6 +719,10 @@ body.light-mode .text-link {
     top: -0.75rem;
     left: -0.25rem;
     opacity: 0.15;
+}
+
+.testimonial-grid.flowing-panels .testimonial-card {
+    scroll-snap-align: start;
 }
 
 .testimonial-card blockquote {


### PR DESCRIPTION
## Summary
- add a call-to-action link to the Blogspot site alongside the existing hero buttons
- replace the Words from Learners & Partners section with authentic testimonials presented in flowing panels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69087fc93e64832889815892d7f31806